### PR TITLE
Allow for path and filename discrepencies

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,10 +39,15 @@ def setDatesFromTitles(videoObjects: list[Movie], channelFolder: str) -> list[Mo
 # Then, parse the year, month, and day out of the singular no-space string.
 # returns a datetime object, as required by plexapi.video.originallyAvailableAt
 def getDateFromTitle(title: str) -> datetime:
-    date = title.split(" ")[0]
-    year = int(date[:4])
-    month = int(date[4:6])
-    day = int(date[6:8])
+    try:
+        date = title.split(" ")[0]
+        year = int(date[:4])
+        month = int(date[4:6])
+        day = int(date[6:8])
+    except:
+        year = 1970
+        month = 1
+        day = 1
     return datetime(year, month, day)
 
 
@@ -334,7 +339,7 @@ def run():
         channelSpecificVideos = [
             video
             for video in allYoutubeVideos
-            if video.locations[0].startswith(channelFolder)
+            if channelName in video.locations[0]
             and video.locations[0].endswith("mkv")
         ]
 


### PR DESCRIPTION
Change in getDateFromTitle allows files that do not conform to the expected date format (but are still the specified format) to be added with the default date of 1970-01-01. This is not necessarily the most elegant solution, but does allow the script to function, while still adding all video files.

Change at line 342 makes the channel match logic simply check if the channel name/ID exists in the plex-provided path, rather than trying to match the whole path exactly. This is helpful if the path plex sees is not identical to the filepath that the script sees, ex: if Plex is run in a docker, and the script is run outside the docker.